### PR TITLE
Update index.test.ts

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -42,6 +42,17 @@ describe('host is corrupted (is empty somehow)', () => {
     expect(host).toBe('localhost:4000')
   })
 
+  test('only from 127.0.0.1 passed in', () => {
+    window.location.host = '127.0.0.1:4000'
+    const { protocol, host, origin } = nextAbsoluteUrl(
+      undefined,
+      'localhost:6000'
+    )
+    expect(origin).toBe('http://127.0.0.1:4000')
+    expect(protocol).toBe('http:')
+    expect(host).toBe('localhost:4000')
+  })
+  
   test('both arguments are passed in', () => {
     const req = {
       headers: {

--- a/index.test.ts
+++ b/index.test.ts
@@ -30,6 +30,17 @@ describe('host is corrupted (is empty somehow)', () => {
     expect(protocol).toBe('http:')
     expect(host).toBe('localhost:9000')
   })
+  
+  test('only from local network passed in', () => {
+    window.location.host = '192.168.88.156:4000'
+    const { protocol, host, origin } = nextAbsoluteUrl(
+      undefined,
+      'localhost:6000'
+    )
+    expect(origin).toBe('http://192.168.88.156:4000')
+    expect(protocol).toBe('http:')
+    expect(host).toBe('localhost:4000')
+  })
 
   test('both arguments are passed in', () => {
     const req = {

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ function absoluteUrl(
 ) {
   let host =
     (req?.headers ? req.headers.host : window.location.host) || localhostAddress
-  let protocol = /^localhost(:\d+)?$/.test(host) ? 'http:' : 'https:'
+  let protocol = isLocalNetwork(host) ? 'http:' : 'https:'
 
   if (
     req &&
@@ -29,6 +29,16 @@ function absoluteUrl(
     host,
     origin: protocol + '//' + host,
   }
+}
+
+function isLocalNetwork(hostname = window.location.host) {
+    return (
+        hostname.startsWith('localhost') ||
+        hostname.startsWith('127.0.0.1') ||
+        hostname.startsWith('192.168.') ||
+        hostname.startsWith('10.0.') ||
+        hostname.endsWith('.local')
+    );
 }
 
 export default absoluteUrl


### PR DESCRIPTION
if the request is done within the local network then HTTPS should be skipped.

The tests in this PR should fail until the core is fixed.

Closes https://github.com/jakeburden/next-absolute-url/issues/17